### PR TITLE
Improve Setting Panel

### DIFF
--- a/Flow.Launcher.Plugin.Snippets/SettingPanel.xaml
+++ b/Flow.Launcher.Plugin.Snippets/SettingPanel.xaml
@@ -8,7 +8,7 @@
              d:DesignHeight="300" d:DesignWidth="300">
 
     <StackPanel Orientation="Vertical" Margin="{StaticResource SettingPanelMargin}">
-        <StackPanel Orientation="Horizontal">
+        <WrapPanel Orientation="Horizontal">
             
             <Button Click="ButtonOpenManage_OnClick" Margin="{StaticResource SettingPanelItemRightTopBottomMargin}" VerticalAlignment="Center"
                     Content="{DynamicResource snippets_plugin_manage_snippets}">
@@ -29,10 +29,10 @@
             <Button Click="ButtonClear_OnClick" Margin="{StaticResource SettingPanelItemTopBottomMargin}" VerticalAlignment="Center"
                     Content="{DynamicResource snippets_plugin_clear}">
             </Button>
-            
-        </StackPanel>
 
-        <StackPanel Orientation="Horizontal">
+        </WrapPanel>
+
+        <WrapPanel Orientation="Horizontal">
 
             <Label VerticalAlignment="Center" Margin="{StaticResource SettingPanelItemRightTopBottomMargin}" 
                    Content="{DynamicResource snippets_plugin_storage_mode}">
@@ -47,7 +47,7 @@
                     Content="{DynamicResource snippets_plugin_change_and_restart_app}">
             </Button>
 
-        </StackPanel>
+        </WrapPanel>
     </StackPanel>
 
 </UserControl>


### PR DESCRIPTION
# Changes

- Use static resources from Flow Launcher to unify setting panel design with Flow Launcher
- Use WrapPanel to replace StackPanel to avoid possible out bound issue (If there are many controls, WrapPanel will put controls to the next row while StackPanel does not)

# Test

- Original:

![Screenshot 2025-07-07 154038](https://github.com/user-attachments/assets/7856d6a1-dfbb-4271-9d18-0d8eaa492bf2)

- After

![image](https://github.com/user-attachments/assets/0b083c6f-7aff-4d9c-8410-37dab69aa1cb)