### PR TITLE
Adjust margins for Auto Paste setting in SettingPanel

### DIFF
--- a/Flow.Launcher.Plugin.Snippets/SettingPanel.xaml
+++ b/Flow.Launcher.Plugin.Snippets/SettingPanel.xaml
@@ -49,11 +49,11 @@
 
         </WrapPanel>
         
-        <WrapPanel Orientation="Horizontal" Margin="0,10,0,0">
+        <WrapPanel Orientation="Horizontal">
             <CheckBox Name="CheckBoxAutoPaste" Content="{DynamicResource snippets_plugin_auto_paste_enabled}" 
                       Margin="{StaticResource SettingPanelItemRightTopBottomMargin}" 
                       VerticalAlignment="Center" Checked="CheckBoxAutoPaste_Checked" Unchecked="CheckBoxAutoPaste_Unchecked"/>
-            <Label Content="{DynamicResource snippets_plugin_auto_paste_description}" 
+            <Label Content="{DynamicResource snippets_plugin_auto_paste_description}" Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                    FontStyle="Italic" VerticalAlignment="Center"/>
         </WrapPanel>
     </StackPanel>


### PR DESCRIPTION
Follow on with #13. Removed top margin from WrapPanel and added margin to the description label for improved layout and spacing.

Original:
<img width="988" height="295" alt="image" src="https://github.com/user-attachments/assets/17617246-087a-4b74-bca2-de12f97c6dda" />

After:
<img width="1009" height="347" alt="image" src="https://github.com/user-attachments/assets/0e1a909c-e0e2-4980-b123-b2a6dc4fbb82" />
