### PR TITLE
Add dynamic variable expansion for date and time in snippets

### DIFF
--- a/Flow.Launcher.Plugin.Snippets/Main.cs
+++ b/Flow.Launcher.Plugin.Snippets/Main.cs
@@ -80,8 +80,11 @@ namespace Flow.Launcher.Plugin.Snippets
                 {
                     try
                     {
+                        // Expand variables before copying to clipboard
+                        var expandedValue = VariableExpander.Expand(value);
+                        
                         // copy to clipboard first
-                        _context.API.CopyToClipboard(value, showDefaultNotification: false);
+                        _context.API.CopyToClipboard(expandedValue, showDefaultNotification: false);
 
                         // after Flow Launcher hides, wait until Flow Launcher no longer has focus and paste into previous active window
                         if (_settings.AutoPasteEnabled)

--- a/Flow.Launcher.Plugin.Snippets/Main_Test.cs
+++ b/Flow.Launcher.Plugin.Snippets/Main_Test.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using Flow.Launcher.Plugin.Snippets.Json;
 using Flow.Launcher.Plugin.Snippets.Sqlite;
+using Flow.Launcher.Plugin.Snippets.Util;
 
 namespace Flow.Launcher.Plugin.Snippets;
 
@@ -14,7 +15,8 @@ public class Main_Test
     {
         // test_json_settings();
         // test_sqlite_add();
-        test_sqlite_query();
+        // test_sqlite_query();
+        test_variable_expander();
     }
 
     private static void test_sqlite_query()
@@ -70,5 +72,63 @@ public class Main_Test
         var v1 = sm.GetByKey("key1");
         Console.WriteLine(v1 == null);
         Console.WriteLine(v1);
+    }
+    
+    private static void test_variable_expander()
+    {
+        Console.WriteLine("Testing VariableExpander...\n");
+        
+        // Test basic variables
+        Console.WriteLine("1. Basic date variable:");
+        var result1 = VariableExpander.Expand("Today is {{date}}");
+        Console.WriteLine($"   Input: 'Today is {{{{date}}}}'");
+        Console.WriteLine($"   Output: '{result1}'\n");
+        
+        Console.WriteLine("2. Basic time variable:");
+        var result2 = VariableExpander.Expand("Current time: {{time}}");
+        Console.WriteLine($"   Input: 'Current time: {{{{time}}}}'");
+        Console.WriteLine($"   Output: '{result2}'\n");
+        
+        Console.WriteLine("3. Date and time together:");
+        var result3 = VariableExpander.Expand("{{datetime}} - Timestamp: {{timestamp}}");
+        Console.WriteLine($"   Input: '{{{{datetime}}}} - Timestamp: {{{{timestamp}}}}'");
+        Console.WriteLine($"   Output: '{result3}'\n");
+        
+        Console.WriteLine("4. Date components:");
+        var result4 = VariableExpander.Expand("Year: {{year}}, Month: {{month}}, Day: {{day}}");
+        Console.WriteLine($"   Input: 'Year: {{{{year}}}}, Month: {{{{month}}}}, Day: {{{{day}}}}'");
+        Console.WriteLine($"   Output: '{result4}'\n");
+        
+        Console.WriteLine("5. Time components:");
+        var result5 = VariableExpander.Expand("{{hour}}:{{minute}}:{{second}}");
+        Console.WriteLine($"   Input: '{{{{hour}}}}:{{{{minute}}}}:{{{{second}}}}'");
+        Console.WriteLine($"   Output: '{result5}'\n");
+        
+        Console.WriteLine("6. Custom date format:");
+        var result6 = VariableExpander.Expand("{{date:MM/dd/yyyy}}");
+        Console.WriteLine($"   Input: '{{{{date:MM/dd/yyyy}}}}'");
+        Console.WriteLine($"   Output: '{result6}'\n");
+        
+        Console.WriteLine("7. Custom time format:");
+        var result7 = VariableExpander.Expand("{{time:hh:mm tt}}");
+        Console.WriteLine($"   Input: '{{{{time:hh:mm tt}}}}'");
+        Console.WriteLine($"   Output: '{result7}'\n");
+        
+        Console.WriteLine("8. Multiple variables in text:");
+        var result8 = VariableExpander.Expand("Meeting on {{date}} at {{time}}. File: meeting_{{timestamp}}.txt");
+        Console.WriteLine($"   Input: 'Meeting on {{{{date}}}} at {{{{time}}}}. File: meeting_{{{{timestamp}}}}.txt'");
+        Console.WriteLine($"   Output: '{result8}'\n");
+        
+        Console.WriteLine("9. Text without variables (should remain unchanged):");
+        var result9 = VariableExpander.Expand("This is plain text without any variables");
+        Console.WriteLine($"   Input: 'This is plain text without any variables'");
+        Console.WriteLine($"   Output: '{result9}'\n");
+        
+        Console.WriteLine("10. Unknown variable (should remain unchanged):");
+        var result10 = VariableExpander.Expand("This has an {{unknown}} variable");
+        Console.WriteLine($"   Input: 'This has an {{{{unknown}}}} variable'");
+        Console.WriteLine($"   Output: '{result10}'\n");
+        
+        Console.WriteLine("All tests completed!");
     }
 }

--- a/Flow.Launcher.Plugin.Snippets/Util/VariableExpander.cs
+++ b/Flow.Launcher.Plugin.Snippets/Util/VariableExpander.cs
@@ -44,7 +44,7 @@ public static class VariableExpander
                     "date" => now.ToString(format ?? "yyyy-MM-dd"),
                     "time" => now.ToString(format ?? "HH:mm:ss"),
                     "datetime" => now.ToString(format ?? "yyyy-MM-dd HH:mm:ss"),
-                    "timestamp" => ((DateTimeOffset)now).ToUnixTimeSeconds().ToString(),
+                    "timestamp" => new DateTimeOffset(now).ToUnixTimeSeconds().ToString(),
                     "year" => now.Year.ToString(),
                     "month" => now.Month.ToString("D2"),
                     "day" => now.Day.ToString("D2"),

--- a/Flow.Launcher.Plugin.Snippets/Util/VariableExpander.cs
+++ b/Flow.Launcher.Plugin.Snippets/Util/VariableExpander.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Flow.Launcher.Plugin.Snippets.Util;
+
+/// <summary>
+/// Utility class for expanding variables in snippet values.
+/// Supports date and time variables with custom formatting.
+/// </summary>
+public static class VariableExpander
+{
+    /// <summary>
+    /// Expands variables in the input text.
+    /// Supported variables:
+    /// - {{date}} or {{date:format}} - Current date
+    /// - {{time}} or {{time:format}} - Current time
+    /// - {{datetime}} or {{datetime:format}} - Current date and time
+    /// - {{timestamp}} - Unix timestamp
+    /// - {{year}}, {{month}}, {{day}}, {{hour}}, {{minute}}, {{second}} - Date/time components
+    /// </summary>
+    /// <param name="text">The text containing variables</param>
+    /// <returns>The text with variables expanded</returns>
+    public static string Expand(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var now = DateTime.Now;
+        
+        // Pattern to match {{variable}} or {{variable:format}}
+        var pattern = @"\{\{([a-zA-Z]+)(?::([^}]+))?\}\}";
+        
+        return Regex.Replace(text, pattern, match =>
+        {
+            var variableName = match.Groups[1].Value.ToLowerInvariant();
+            var format = match.Groups[2].Success ? match.Groups[2].Value : null;
+            
+            try
+            {
+                return variableName switch
+                {
+                    "date" => now.ToString(format ?? "yyyy-MM-dd"),
+                    "time" => now.ToString(format ?? "HH:mm:ss"),
+                    "datetime" => now.ToString(format ?? "yyyy-MM-dd HH:mm:ss"),
+                    "timestamp" => ((DateTimeOffset)now).ToUnixTimeSeconds().ToString(),
+                    "year" => now.Year.ToString(),
+                    "month" => now.Month.ToString("D2"),
+                    "day" => now.Day.ToString("D2"),
+                    "hour" => now.Hour.ToString("D2"),
+                    "minute" => now.Minute.ToString("D2"),
+                    "second" => now.Second.ToString("D2"),
+                    _ => match.Value // Keep original if variable not recognized
+                };
+            }
+            catch (FormatException)
+            {
+                // If custom format is invalid, return the original variable
+                return match.Value;
+            }
+        });
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,7 @@ A plugin for the [Flow launcher](https://github.com/Flow-Launcher/Flow.Launcher)
 - Search and manage snippets
 - Auto-paste functionality (optional)
 - Support for both JSON and SQLite storage
+- **Dynamic variables** for date and time (e.g., `{{date}}`, `{{time}}`, `{{timestamp}}`)
 
 
 ### Compatibility
@@ -46,6 +47,40 @@ A plugin for the [Flow launcher](https://github.com/Flow-Launcher/Flow.Launcher)
 - Paste Delay: Configure the delay (in milliseconds) before pasting
 
 > Note: When changing storage types, data migration is not automatic. Follow the migration steps above.
+
+### Dynamic Variables
+
+Snippets can include dynamic variables that are automatically expanded when the snippet is used. This is useful for inserting current dates, times, and timestamps.
+
+#### Supported Variables
+
+**Date Variables:**
+- `{{date}}` - Current date in ISO format (e.g., `2026-02-10`)
+- `{{date:format}}` - Current date with custom format (e.g., `{{date:MM/dd/yyyy}}` → `02/10/2026`)
+- `{{year}}` - Current year (e.g., `2026`)
+- `{{month}}` - Current month with leading zero (e.g., `02`)
+- `{{day}}` - Current day with leading zero (e.g., `10`)
+
+**Time Variables:**
+- `{{time}}` - Current time in 24-hour format (e.g., `14:30:45`)
+- `{{time:format}}` - Current time with custom format (e.g., `{{time:hh:mm tt}}` → `02:30 PM`)
+- `{{hour}}` - Current hour with leading zero (e.g., `14`)
+- `{{minute}}` - Current minute with leading zero (e.g., `30`)
+- `{{second}}` - Current second with leading zero (e.g., `45`)
+
+**Combined Variables:**
+- `{{datetime}}` - Current date and time (e.g., `2026-02-10 14:30:45`)
+- `{{datetime:format}}` - Date and time with custom format (e.g., `{{datetime:yyyy-MM-dd HH:mm}}`)
+- `{{timestamp}}` - Unix timestamp in seconds (e.g., `1770700117`)
+
+#### Usage Examples
+
+1. **Daily log file**: `log_{{date}}.txt` → `log_2026-02-10.txt`
+2. **Timestamped note**: `Meeting notes - {{datetime}}` → `Meeting notes - 2026-02-10 14:30:45`
+3. **Custom date format**: `Report {{date:MMMM dd, yyyy}}` → `Report February 10, 2026`
+4. **Backup filename**: `backup_{{timestamp}}.zip` → `backup_1770700117.zip`
+
+For custom formats, you can use any valid [.NET date and time format string](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings).
 
 ### Snapshots 
 


### PR DESCRIPTION
Snippets can now include variables like `{{date}}`, `{{time}}`, and `{{timestamp}}` that expand to current values when used.

## Changes

- **New: `VariableExpander` utility** - Regex-based expansion supporting 12 variable types with optional format strings
- **Integration: `Main.cs`** - Expand variables before clipboard copy (3-line change in Action handler)
- **Documentation** - Variable reference and examples added to README

## Supported Variables

**Date**: `{{date}}`, `{{year}}`, `{{month}}`, `{{day}}`  
**Time**: `{{time}}`, `{{hour}}`, `{{minute}}`, `{{second}}`  
**Combined**: `{{datetime}}`, `{{timestamp}}`  
**Custom formats**: `{{date:MM/dd/yyyy}}`, `{{time:hh:mm tt}}`, etc.

## Example

Store snippet with value:
```
Meeting notes - {{datetime}}
File: notes_{{timestamp}}.txt
```

Expands to:
```
Meeting notes - 2026-02-10 14:30:45
File: notes_1770700200.txt
```

Variables are stored as-is in the database and expanded only on use. Unknown variables are preserved unchanged for backward compatibility.

Resolve #14